### PR TITLE
Message Handler Middleware

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    slack_bot-events (0.3.0)
+    slack_bot-events (0.4.0)
       class_composer (~> 1.0)
       faraday
       faye-websocket

--- a/lib/slack_bot/events/client.rb
+++ b/lib/slack_bot/events/client.rb
@@ -17,10 +17,10 @@ module SlackBot
           end
 
           websocket.on :message do |socket_event|
-            process_message(socket_event: socket_event) do |parsed_data:, schema: nil|
+            process_message(socket_event: socket_event) do |listener:, parsed_data:, schema: nil|
               case parsed_data["type"]
               when "events_api"
-                events_api(schema: schema, parsed_data: parsed_data)
+                events_api(handler: listener[:handler], schema: schema, parsed_data: parsed_data)
               end
             end
           end
@@ -37,8 +37,11 @@ module SlackBot
 
       def process_message(socket_event:)
         schema_data = Schematize.call(data: socket_event.data)
-        SlackBot::Events.message_middleware.invoke_message(type: :message, socket_event: socket_event, **schema_data) do
-          yield(**schema_data) if block_given?
+
+        listener = find_listener(schema: schema_data[:schema]) # Events.config.listeners[schema_data[:schema]&.type.to_sym]
+
+        SlackBot::Events.message_middleware.invoke_message(websocket: websocket, listener: listener, type: :message, socket_event: socket_event, **schema_data) do
+          yield(listener: listener, **schema_data) if block_given?
         end
       end
 
@@ -48,33 +51,22 @@ module SlackBot
         end
       end
 
-      def events_api(schema:, parsed_data:)
-        if Events.config.print_tldr
-          Events.logger.info { schema.tldr }
-        end
+      def events_api(handler:, schema:, parsed_data:)
+        return if listener.nil?
 
-        object = Events.config.listeners[schema.type.to_sym]
-        if object
-          safe_handler(type: schema.type.to_sym, object: object, schema: schema, parsed_data: parsed_data)
-        end
+        Events.logger.info { schema.tldr } if Events.config.print_tldr
 
-        websocket.send("#{{ envelope_id: schema.envelope_id }.to_json}")
+        # This gets rescued in the MessageHandler middleware
+        # on_success and on_failure happens there as well
+        handler.call(schema: schema, raw_data: parsed_data)
       end
 
       private
 
-      def safe_handler(type:, object:, schema:, parsed_data:)
-        Events.logger.info "Received Handler for #{type}"
-        object[:handler].call(schema: schema, raw_data: parsed_data)
-        object[:on_success]&.call(schema)
-      rescue => error
-        Events.logger.error("#{object[:handler]} returned #{error.class} => #{error.message}. Safely returning to websocket. #{error.backtrace[0...10]}")
+      def find_listener(schema:)
+        return nil if schema.nil?
 
-        begin
-          object[:on_failure]&.call(schema, error)
-        rescue => on_failure_error
-           Events.logger.error("Failure occured during on_failure block. #{on_failure_error}")
-        end
+        Events.config.listeners[schema.type.to_sym]
       end
 
       def websocket
@@ -93,9 +85,7 @@ module SlackBot
       end
 
       def faraday_headers
-        {
-          'Authorization' => "Bearer #{SlackBot::Events.config.client_socket_token}"
-        }
+        { 'Authorization' => "Bearer #{SlackBot::Events.config.client_socket_token}" }
       end
     end
   end

--- a/lib/slack_bot/events/configuration.rb
+++ b/lib/slack_bot/events/configuration.rb
@@ -26,6 +26,12 @@ module SlackBot
       add_composer :close_middleware, allowed: Middleware::Chain, default: Middleware::Chain.new(type: :close)
       add_composer :envelope_acknowledge, allowed: Symbol, default: DEFAULT_ACKNOWLEDGE, validator: ->(val) { ALLOWED_ACKNOWLEDGE.include?(val) }, invalid_message: ->(_) { "Must by a Symbol in #{ALLOWED_ACKNOWLEDGE}" }
 
+      ALLOWED_ACKNOWLEDGE.each do |ack|
+        define_method :"acknowledge_#{ack}?" do
+          envelope_acknowledge == ack
+        end
+      end
+
       def register_listener(name:, handler:, on_success: nil, on_failure: nil)
         if event_handler = listeners[name.to_sym]
           logger.warn "`#{name}` already exists as listener event. Reseting with new input"

--- a/lib/slack_bot/events/middleware/message_handler.rb
+++ b/lib/slack_bot/events/middleware/message_handler.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+module SlackBot
+  module Events
+    module Middleware
+      class MessageHandler
+        def call(schema:, websocket:, listener:, **params)
+          if SlackBot::Events.config.acknowledge_on_receive?
+            acknowledge!(websocket: websocket, schema: schema)
+          end
+
+          yield
+
+          listener[:on_success]&.call(schema) if listener
+
+          if SlackBot::Events.config.acknowledge_on_success? || SlackBot::Events.config.acknowledge_on_complete?
+            acknowledge!(websocket: websocket, schema: schema)
+          end
+        rescue StandardError => error
+          puts error.message
+          puts error.backtrace
+          Events.logger.error do
+            "#{listener[:handler]} returned #{error.class} => #{error.message}. #{error.backtrace[0...10]}")
+          end
+
+          begin
+            listener[:on_failure]&.call(schema, error) if listener
+          rescue StandardError => on_failure_error
+             Events.logger.error("Failure occured during on_failure block. #{on_failure_error}")
+          end
+
+          if SlackBot::Events.config.acknowledge_on_complete?
+            acknowledge!(websocket: websocket, schema: schema)
+          elsif SlackBot::Events.config.acknowledge_on_success?
+            Events.logger.debug do
+              "Envelope acknowledgment skipped. Ackowledgment on success only. Slack may send a duplicate message"
+            end
+          end
+        end
+
+        private
+
+        def acknowledge!(websocket:, schema:)
+          return if schema.nil?
+
+          websocket.send("#{{ envelope_id: schema.envelope_id }.to_json}")
+          Events.logger.debug { "Envelope acknowledgment completed [#{SlackBot::Events.config.envelope_acknowledge}]" }
+        end
+      end
+    end
+  end
+end

--- a/lib/slack_bot/events/middleware/message_handler.rb
+++ b/lib/slack_bot/events/middleware/message_handler.rb
@@ -20,7 +20,7 @@ module SlackBot
           puts error.message
           puts error.backtrace
           Events.logger.error do
-            "#{listener[:handler]} returned #{error.class} => #{error.message}. #{error.backtrace[0...10]}")
+            "#{listener[:handler]} returned #{error.class} => #{error.message}. #{error.backtrace[0...10]}"
           end
 
           begin

--- a/lib/slack_bot/events/version.rb
+++ b/lib/slack_bot/events/version.rb
@@ -2,6 +2,6 @@
 
 module SlackBot
   module Events
-    VERSION = "0.3.0"
+    VERSION = "0.4.0"
   end
 end


### PR DESCRIPTION
## Changes
- Message handling composes of Envelope acknowledgment, `on_success` and `on_failure` listener hooks
- Move Message Handling as part of the Message Middleware
- configuration to decision when the to acknowledge the message: 
  - `on_receive`: Before the message gets processed
  - `on_success`: Only acknowledge when both the process handling and the `on_success` hooks succeed -- Not acknowledging the message envelope will mean slack will retry again after 3 seconds, after 1 minute, and then again in 5 minutes ([Events Retry Attempts](https://api.slack.com/interactivity/handling#acknowledgment_response))
  - `on_complete`: Acknowledge message after message has finished processing (fail or success processing)