### PR TITLE
[Fix] Receiver called incorrect values

### DIFF
--- a/lib/slack_bot/events.rb
+++ b/lib/slack_bot/events.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "pry"
-
 require "slack_bot/events/configuration"
 require "slack_bot/events/client"
 require "slack_bot/events/middleware/chain"

--- a/lib/slack_bot/events/client.rb
+++ b/lib/slack_bot/events/client.rb
@@ -52,7 +52,7 @@ module SlackBot
       end
 
       def events_api(handler:, schema:, parsed_data:)
-        return if listener.nil?
+        return if handler.nil?
 
         Events.logger.info { schema.tldr } if Events.config.print_tldr
 

--- a/lib/slack_bot/events/configuration.rb
+++ b/lib/slack_bot/events/configuration.rb
@@ -15,11 +15,7 @@ module SlackBot
         :on_receive,
       ]
 
-      add_composer :client_id, allowed: String, default: ENV["SLACK_CLIENT_ID"]
-      add_composer :client_secret, allowed: String, default: ENV["SLACK_CLIENT_SECRET"]
-      add_composer :client_signing_secret, allowed: String, default: ENV["SLACK_SIGNING_SECRET"]
       add_composer :client_socket_token, allowed: String, default: ENV["SLACK_SOCKET_TOKEN"]
-      add_composer :client_verification_token, allowed: String, default: ENV["SLACK_VERIFICATION_TOKEN"]
       add_composer :print_tldr, allowed: [true.class, false.class], default: true
       add_composer :message_middleware, allowed: Middleware::Chain, default: Middleware::Chain.new(type: :message)
       add_composer :open_middleware, allowed: Middleware::Chain, default: Middleware::Chain.new(type: :open)

--- a/lib/slack_bot/events/version.rb
+++ b/lib/slack_bot/events/version.rb
@@ -2,6 +2,6 @@
 
 module SlackBot
   module Events
-    VERSION = "0.4.0"
+    VERSION = "0.4.1"
   end
 end


### PR DESCRIPTION
This is why spec tests are needed and will be added in a future PR.

---

- Pry not a runtime dependency and causes failures when not included
- Incorrect variable name used and caused failures for all things that have handlers attributed to it